### PR TITLE
Add Asana panel

### DIFF
--- a/asanabot.js
+++ b/asanabot.js
@@ -1,0 +1,25 @@
+var Asana = require('asana');
+var util = require('util');
+var config = require(__dirname + '/config.js');
+
+// Here we are using the API key for basic auth - todo switch to Oauth
+var client = Asana.Client.create().useBasicAuth(config.asana.api_key);
+
+function getTasks() {
+  var status = config.asana.status.split(',');
+  return client.users.me()
+    .then(function(user) {
+      var userId = user.id;
+      var workspace = user.workspaces.filter(workspace => workspace.name === config.asana.workspace)[0];
+      return client.tasks.findAll({
+        assignee: userId,
+        workspace: workspace.id,
+        completed_since: 'now',
+        opt_fields: 'id,name,assignee_status,completed'
+      });
+    })
+    .then(response => response.data)
+    .filter(task => status.includes(task.assignee_status));
+}
+
+module.exports.getTasks = getTasks;

--- a/care.js
+++ b/care.js
@@ -2,6 +2,7 @@
 var config = require(__dirname + '/config.js');
 var twitterbot = require(__dirname + '/twitterbot.js');
 var gitbot = require(__dirname + '/gitbot.js');
+var asanabot = require(__dirname + '/asanabot.js');
 var pomodoro = require(__dirname + '/pomodoro.js');
 var ansiArt = require('ansi-art').default;
 
@@ -73,7 +74,7 @@ screen.key(['p', 'C-p'], function(ch, key) {
   if (inPomodoroMode) {
     pomodoroObject.stop();
     inPomodoroMode = false;
-    doTheTweets();
+    // doTheTweets();
     parrotBox.removeLabel('');
   } else {
     parrotBox.setLabel(' 🍅 ');
@@ -91,16 +92,18 @@ var weekBox = grid.set(6, 0, 6, 6, blessed.box, makeScrollBox(' 📝  Week '));
 var commits = grid.set(0, 6, 6, 2, contrib.bar, makeGraphBox('Commits'));
 var parrotBox = grid.set(6, 6, 6, 6, blessed.box, makeScrollBox(''));
 
-var tweetBoxes = {}
-tweetBoxes[config.twitter[1]] = grid.set(2, 8, 2, 4, blessed.box, makeBox(' 💖 '));
-tweetBoxes[config.twitter[2]] = grid.set(4, 8, 2, 4, blessed.box, makeBox(' 💬 '));
+// var tweetBoxes = {}
+// tweetBoxes[config.twitter[1]] = grid.set(2, 8, 2, 4, blessed.box, makeBox(' 💖 '));
+// tweetBoxes[config.twitter[2]] = grid.set(4, 8, 2, 4, blessed.box, makeBox(' 💬 '));
+
+var asanaBox = grid.set(2, 8, 4, 4, blessed.box, makeScrollBox(' Asana Tasks '));
 
 tick();
 setInterval(tick, 1000 * 60 * config.updateInterval);
 
 function tick() {
   doTheWeather();
-  doTheTweets();
+  doTheTasks();
   doTheCodes();
 }
 
@@ -124,6 +127,17 @@ function doTheWeather() {
     } else {
       weatherBox.content = 'Having trouble fetching the weather for you :(';
     }
+  });
+}
+
+function doTheTasks() {
+  // show loading message while loading commits
+  asanaBox.content = '⏳ one second please...tiny asana bot is looking for tiny tasks! ⏳';
+  screen.render();
+
+  asanabot.getTasks().then(function(list) {
+    asanaBox.content = list.map(item => (`- ${item.name}`)).join('\n');
+    screen.render();
   });
 }
 

--- a/config.js
+++ b/config.js
@@ -34,6 +34,12 @@ var config = {
     access_token_secret: process.env.TTC_ACCESS_TOKEN_SECRET || process.env.ACCESS_TOKEN_SECRET || 'none',
   },
 
+  asana: {
+    api_key: process.env.ASANA_API_KEY || 'none',
+    workspace: process.env.ASANA_WORKSPACE || 'none',
+    status: process.env.ASANA_STATUS || 'today',
+  },
+
   // Pomodoro Settings
   runningDuration: process.env.TTC_POMODORO || 20,
   breakDuration: process.env.TTC_BREAK || 5,

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "repository": "https://github.com/notwaldorf/tiny-care-terminal.git",
   "dependencies": {
     "ansi-art": "^1.2.3",
+    "asana": "^0.15.1",
     "blessed": "^0.1.81",
     "blessed-contrib": "^4.7.5",
     "chalk": "^2.3.2",


### PR DESCRIPTION
This commit disables the twitter panels, and replaces them with a simple
Asana panel. This adds three configuration settings for Asana, the
Access Token, a workspace name and the status of tasks you'd like to
display (defaults to today). In order to us Asana, you will need to
configure the Access Token in the Asana dashboard.