### PR TITLE
Get first two pages of Asana tasks

### DIFF
--- a/asanabot.js
+++ b/asanabot.js
@@ -8,7 +8,7 @@ var client = Asana.Client.create().useBasicAuth(config.asana.api_key);
 function getTasks() {
   var status = config.asana.status.split(',');
   return client.users.me()
-    .then(function(user) {
+    .then(function (user) {
       var userId = user.id;
       var workspace = user.workspaces.filter(workspace => workspace.name === config.asana.workspace)[0];
       return client.tasks.findAll({
@@ -18,7 +18,10 @@ function getTasks() {
         opt_fields: 'id,name,assignee_status,completed'
       });
     })
-    .then(response => response.data)
+    .then(collection => {
+      // get up to 100 tasks.
+      return collection.fetch(100).then(tasks => tasks);
+    })
     .filter(task => status.includes(task.assignee_status));
 }
 

--- a/care.js
+++ b/care.js
@@ -75,6 +75,7 @@ screen.key(['p', 'C-p'], function(ch, key) {
     pomodoroObject.stop();
     inPomodoroMode = false;
     // doTheTweets();
+    doTheTasks();
     parrotBox.removeLabel('');
   } else {
     parrotBox.setLabel(' 🍅 ');
@@ -86,17 +87,17 @@ screen.key(['p', 'C-p'], function(ch, key) {
 var grid = new contrib.grid({rows: 12, cols: 12, screen: screen});
 
 // grid.set(row, col, rowSpan, colSpan, obj, opts)
-var weatherBox = grid.set(0, 8, 2, 4, blessed.box, makeScrollBox(' 🌤 '));
+var weatherBox = grid.set(0, 6, 2, 6, blessed.box, makeScrollBox(' 🌤 '));
 var todayBox = grid.set(0, 0, 6, 6, blessed.box, makeScrollBox(' 📝  Last 24 hours '));
 var weekBox = grid.set(6, 0, 6, 6, blessed.box, makeScrollBox(' 📝  Week '));
-var commits = grid.set(0, 6, 6, 2, contrib.bar, makeGraphBox('Commits'));
-var parrotBox = grid.set(6, 6, 6, 6, blessed.box, makeScrollBox(''));
+var commits = grid.set(6, 6, 6, 2, contrib.bar, makeGraphBox('Commits'));
+var parrotBox = grid.set(6, 8, 6, 4, blessed.box, makeScrollBox(''));
 
 // var tweetBoxes = {}
 // tweetBoxes[config.twitter[1]] = grid.set(2, 8, 2, 4, blessed.box, makeBox(' 💖 '));
 // tweetBoxes[config.twitter[2]] = grid.set(4, 8, 2, 4, blessed.box, makeBox(' 💬 '));
 
-var asanaBox = grid.set(2, 8, 4, 4, blessed.box, makeScrollBox(' Asana Tasks '));
+var asanaBox = grid.set(2, 6, 4, 6, blessed.box, makeScrollBox(' Asana Tasks '));
 
 tick();
 setInterval(tick, 1000 * 60 * config.updateInterval);
@@ -104,6 +105,7 @@ setInterval(tick, 1000 * 60 * config.updateInterval);
 function tick() {
   doTheWeather();
   doTheTasks();
+  doTheParrot();
   doTheCodes();
 }
 
@@ -139,6 +141,12 @@ function doTheTasks() {
     asanaBox.content = list.map(item => (`- ${item.name}`)).join('\n');
     screen.render();
   });
+}
+
+// run the parrot ascii with out twitter
+function doTheParrot() {
+  parrotBox.content = getAnsiArt('Hi! You\'re doing great!!!')
+  screen.render();
 }
 
 function doTheTweets() {


### PR DESCRIPTION
Asana only returns 50 tasks per page, and the tasks are in descending.
This commit make sure that we are getting up to 100 tasks, so that we
can filter as many as possible; for instance if we have 75 tasks, and
only the last 10 have the status 'today', retrieving the first page
of tasks will not display any tasks on the dashboard.
Additionally, changes the dashboard format as well, moving some of the
panels around.