### PR TITLE
Use workspace gid instead of project gid

### DIFF
--- a/care.js
+++ b/care.js
@@ -99,8 +99,16 @@ var asanaBox = grid.set(0, 6, 6, 6, blessed.listtable, makeListTable(' Asana Tas
 
 asanaBox.on('select', (data, index) => {
   var selectedTask = asanaTasks[index - 1];
-  var project = selectedTask.projects[0];
-  openBrowser(`https://app.asana.com/0/${project.gid}/${selectedTask.gid}`);
+  var { workspace, projects } = selectedTask;
+
+  if (projects[0] && projects[0].gid) {
+    openBrowser(`https://app.asana.com/0/${projects[0].gid}/${selectedTask.gid}`);
+  }
+
+  if  (workspace && workspace.gid) {
+    openBrowser(`https://app.asana.com/0/${workspace.gid}/${selectedTask.gid}`);
+  } 
+  
 });
 
 tick();


### PR DESCRIPTION
Not all tasks are assigned to a project; This commit updates the task on
select event to fall back to a workspace id when creating the task url,
if a project id is not available to the task.